### PR TITLE
Use the gpac permalink instead of building it

### DIFF
--- a/.github/workflows/cfc.yml
+++ b/.github/workflows/cfc.yml
@@ -30,20 +30,13 @@ jobs:
           poetry env use "3.11"
           poetry install --no-interaction
 
-      - name: Restore GPAC Cache
-        uses: actions/cache/restore@v3
-        with:
-          path: /tmp/gpac
-          key: ${{ runner.os }}-gpac-
-          restore-keys: ${{ runner.os }}-gpac-
-
-      - name: Setup MP4Box
+      - name: Install GPAC
         run: |
+          wget -O /tmp/gpac.deb https://download.tsi.telecom-paristech.fr/gpac/new_builds/gpac_latest_head_linux64.deb
+          sudo apt update
+          sudo apt install -y /tmp/gpac.deb
           mkdir -p $HOME/.gpac
-          mkdir -p $HOME/.local/bin
           touch $HOME/.gpac/creds.key
-          cp -r /tmp/gpac/ $HOME/.local/bin
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Configure GitHub handle
         run: |

--- a/.github/workflows/chores.yml
+++ b/.github/workflows/chores.yml
@@ -6,36 +6,6 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  gpac:
-    name: Build GPAC
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: gpac/gpac
-
-      - name: Get latest commit
-        id: get-latest-commit
-        run: |
-          echo "latest-commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-      - name: GPAC Cache
-        id: gpac-cache
-        uses: actions/cache@v3
-        with:
-          path: /tmp/gpac
-          key: ${{ runner.os }}-gpac-${{ steps.get-latest-commit.outputs.latest-commit }}
-
-      - name: GPAC Build
-        if: steps.gpac-cache.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get install -y build-essential pkg-config git zlib1g-dev
-          ./configure --static-bin
-          make -j$(nproc)
-          mkdir -p /tmp/gpac
-          cp -r bin/gcc/ /tmp/gpac
-
   lfscache:
     name: Keep LFS Cache Warm
     runs-on: ubuntu-latest


### PR DESCRIPTION
This ensures that we absolutely get the latest MP4Box build for conformance file feature extraction. It uses the permalink found in [GPAC's website](https://gpac.wp.imt.fr/downloads/gpac-nightly-builds/).